### PR TITLE
Add prefix toggle feature for commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laststance/git-gpt-commit",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "An AI-powered Git extension that generates commit messages using OpenAI's GPT-3, streamlining the commit process and improving developer productivity.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- Introduced a closure-based prefixState for managing the state of commit message prefixes safely.
- Added functionality to enable or disable commit message prefixes through a new prefix command.
- Updated the